### PR TITLE
support different rotation modes

### DIFF
--- a/TargetSystem/Source/TargetSystem/Private/TargetSystemComponent.cpp
+++ b/TargetSystem/Source/TargetSystem/Private/TargetSystemComponent.cpp
@@ -690,13 +690,19 @@ void UTargetSystemComponent::ControlRotation(const bool ShouldControlRotation) c
 		return;
 	}
 
-	OwnerPawn->bUseControllerRotationYaw = ShouldControlRotation;
+    if (CharacterRotationMode == ECharacterRotationMode::OrientToMovement)
+    {
+        OwnerPawn->bUseControllerRotationYaw = ShouldControlRotation;
+    }
 
-	UCharacterMovementComponent* CharacterMovementComponent = OwnerPawn->FindComponentByClass<UCharacterMovementComponent>();
-	if (IsValid(CharacterMovementComponent))
-	{
-		CharacterMovementComponent->bOrientRotationToMovement = !ShouldControlRotation;
-	}
+    if (CharacterRotationMode == ECharacterRotationMode::OrientToMovement)
+    {
+        UCharacterMovementComponent* CharacterMovementComponent = OwnerPawn->FindComponentByClass<UCharacterMovementComponent>();
+        if (IsValid(CharacterMovementComponent))
+        {
+            CharacterMovementComponent->bOrientRotationToMovement = !ShouldControlRotation;
+        }
+    }
 }
 
 bool UTargetSystemComponent::IsInViewport(TargetInterface Interface) const

--- a/TargetSystem/Source/TargetSystem/Private/TargetSystemComponent.cpp
+++ b/TargetSystem/Source/TargetSystem/Private/TargetSystemComponent.cpp
@@ -693,10 +693,7 @@ void UTargetSystemComponent::ControlRotation(const bool ShouldControlRotation) c
     if (CharacterRotationMode == ECharacterRotationMode::OrientToMovement)
     {
         OwnerPawn->bUseControllerRotationYaw = ShouldControlRotation;
-    }
 
-    if (CharacterRotationMode == ECharacterRotationMode::OrientToMovement)
-    {
         UCharacterMovementComponent* CharacterMovementComponent = OwnerPawn->FindComponentByClass<UCharacterMovementComponent>();
         if (IsValid(CharacterMovementComponent))
         {

--- a/TargetSystem/Source/TargetSystem/Public/TargetSystemComponent.h
+++ b/TargetSystem/Source/TargetSystem/Public/TargetSystemComponent.h
@@ -18,13 +18,13 @@ DECLARE_DYNAMIC_MULTICAST_DELEGATE_OneParam(
 
 DECLARE_DYNAMIC_MULTICAST_DELEGATE_OneParam(
     FComponentOnTargetLockedOnOff,
-    AActor*, TargetActor
+    const AActor*, TargetActor
 );
 
 DECLARE_DYNAMIC_MULTICAST_DELEGATE_TwoParams(
     FComponentSetRotation,
-    AActor*, TargetActor,
-    FRotator, ControlRotation
+    const AActor*, TargetActor,
+    FRotator&, ControlRotation
 );
 
 UENUM(BlueprintType)
@@ -91,12 +91,6 @@ protected:
 
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Target System")
     ECharacterRotationMode CharacterRotationMode = ECharacterRotationMode::OrientToMovement;
-
-    // UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Target System")
-    // bool bChangeOrientRotationToMovementWhenTargeting = true;
-    //
-    // UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Target System")
-    // bool bChangeUseControllerRotationYawWhenTargeting = true;
 
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Target System")
     bool bAutoTargetSwitch = false;

--- a/TargetSystem/Source/TargetSystem/Public/TargetSystemComponent.h
+++ b/TargetSystem/Source/TargetSystem/Public/TargetSystemComponent.h
@@ -11,21 +11,28 @@ struct FTargetActorDetails;
 using TargetInterface = TScriptInterface<ITargetSystemInterface>;
 
 DECLARE_DYNAMIC_MULTICAST_DELEGATE(FOnFinishTargetLock);
-DECLARE_DYNAMIC_MULTICAST_DELEGATE_OneParam(FOnTargetIsDead, TScriptInterface<ITargetSystemInterface>, Interface);
+DECLARE_DYNAMIC_MULTICAST_DELEGATE_OneParam(
+    FOnTargetIsDead,
+    TScriptInterface<ITargetSystemInterface>, Interface
+);
 
 DECLARE_DYNAMIC_MULTICAST_DELEGATE_OneParam(
     FComponentOnTargetLockedOnOff,
-    AActor*,
-    TargetActor
+    AActor*, TargetActor
 );
 
 DECLARE_DYNAMIC_MULTICAST_DELEGATE_TwoParams(
     FComponentSetRotation,
-    AActor*,
-    TargetActor,
-    FRotator,
-    ControlRotation
+    AActor*, TargetActor,
+    FRotator, ControlRotation
 );
+
+UENUM(BlueprintType)
+enum class ECharacterRotationMode : uint8
+{
+    OrientToMovement,
+    Strafe,
+};
 
 class UUserWidget;
 class UWidgetComponent;
@@ -81,6 +88,15 @@ protected:
     // Base params
     UPROPERTY(VisibleDefaultsOnly, BlueprintReadOnly, Category = "Target System")
     TSubclassOf<AActor> RequiredClass;
+
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Target System")
+    ECharacterRotationMode CharacterRotationMode = ECharacterRotationMode::OrientToMovement;
+
+    // UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Target System")
+    // bool bChangeOrientRotationToMovementWhenTargeting = true;
+    //
+    // UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Target System")
+    // bool bChangeUseControllerRotationYawWhenTargeting = true;
 
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Target System")
     bool bAutoTargetSwitch = false;


### PR DESCRIPTION
Есть 2 типа поворота персонажа
1) в направление движения
2) всегда смотрит всегда прямо и стрейфится(как у нас сейчас)

Во 2ом варианте манипулировать `bUseControllerRotationYaw` и `bOrientRotationToMovement` - не нужно, иначе персонаж начинает двигаться в направление движения

@DRICODYSS как лучше это сделать 
1) через enum RotationMode и подстраивание настроек там где мы считаем это нужно
2) давать разрабу возможность выбирать чем манипулировать, а чем нет, чет типо `bChangeOrientRotationToMovementWhenTargeting`, `bChangeUseControllerRotationYawWhenTargeting`

Кмк наверное первый варик лучше?
